### PR TITLE
Use the default GITHUB_TOKEN credential

### DIFF
--- a/.github/workflows/building-uploading.yml
+++ b/.github/workflows/building-uploading.yml
@@ -42,9 +42,9 @@ jobs:
           name: bottles
       - name: Publish bottles
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: brew pr-upload --debug --keep-old
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/bumping.yml
+++ b/.github/workflows/bumping.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Bump formulae
         uses: dawidd6/action-homebrew-bump-formula@v3
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           tap: ${{github.repository}}
           livecheck: true

--- a/.github/workflows/uploading.yml
+++ b/.github/workflows/uploading.yml
@@ -16,14 +16,14 @@ jobs:
         uses: Homebrew/actions/git-user-config@master
       - name: Pull bottles
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
           PULL_REQUEST: ${{github.event.pull_request.number}}
           WORKFLOW: building.yml
         run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY --workflows=$WORKFLOW $PULL_REQUEST
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
       - name: Delete branch
         if: github.event.pull_request.head.repo.fork == false
         env:


### PR DESCRIPTION
All actions have a default [GITHUB_TOKEN](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow) secret that has permission to write to the repository itself, including releases. I just tested this myself and it works for uploading bottels and tagging the release.

With this change, your example CI config works out of the box on any tap.
