### PR TITLE
Build linux binaries in container

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,11 +22,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-18.04
-          - macos-11
-          - macos-12
+        include:
+          - os: ubuntu-18.04
+            container:
+              image: ghcr.io/homebrew/ubuntu16.04:master
+              options: --user=linuxbrew
+          - os: macos-11
+          - os: macos-12
     runs-on: ${{matrix.os}}
+    container: ${{matrix.container}}
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master


### PR DESCRIPTION
Hello! I use your workflows as a template for my tap, thank you very much.

To build linux bottles that are maximally portable with older distros, and as much as possible identical to those in upstream homebrew, maybe we should use the same container? Afaict, right now  it builds on the ubuntu-18 image provided by GHA, which changes all the time?

Sorry if I misunderstood.